### PR TITLE
add xAxis.min and .max defaults

### DIFF
--- a/src/scripts/core/cartesian.js
+++ b/src/scripts/core/cartesian.js
@@ -17,6 +17,8 @@
             // type of axis {ordinal|linear|time}
             type: null, // defaults is ordinal (needs to be null here so overrides work)
             categories: undefined,
+            max: undefined,
+            min: undefined,
             innerTickSize: 6,
             outerTickSize: 0,
             tickPadding: 6,


### PR DESCRIPTION
this way these properties can be a documented, rather than
undocumented, feature. see also #166 and #167.

these properties only have an impact if you are using a linear axis.
