### PR TITLE
correct unclosed DIV in bar-stacked example

### DIFF
--- a/examples/showcase/bar/bar-stacked/demo.html
+++ b/examples/showcase/bar/bar-stacked/demo.html
@@ -5,5 +5,6 @@
 <script src="http://cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.js"></script>
 <script src="http://forio.com/tools/contour/contour.min.js"></script>
 
-<div class="chart-title">Winter Olympic Medals by Country<div class="sub-title">Top 10 of All Time<div></div>
+<div class="chart-title">Winter Olympic Medals by Country</div>
+<div class="sub-title">Top 10 of All Time</div>
 <div class="chart bar-stacked"></div>


### PR DESCRIPTION
This fixes the layout of the bar-stacked demo, which has an unclosed div.
