### PR TITLE
allow options.* parameters to be explicitly listed during build-documentation

### DIFF
--- a/src/scripts/core/exportable.js
+++ b/src/scripts/core/exportable.js
@@ -28,13 +28,14 @@
     *
     * ###Example:
     *
-    *     var contour = new Contour(...)
+    *     var chart = new Contour(...)
     *         ...
     *         .exportable()
     *         .render();
+    *
     *     document.getElementById('save').onclick = function () {
-    *         contour.download({
-    *             fileName: 'contour.png'
+    *         chart.download({
+    *             fileName: 'myContourChart.png'
     *         });
     *
     * ###External dependencies:
@@ -97,29 +98,30 @@
             *
             * ###Browser variations:
             *
-            * - Chrome will save the image.
-            * - Firefox and IE10-11 will display a prompt, then save the image.
-            * - IE9 and Safari will open the image in a new tab, enabling the user to manually save the image.
+            * - Chrome saves the image.
+            * - Firefox and IE10-11 display a prompt, then save the image.
+            * - IE9 and Safari open the image in a new tab, enabling the user to manually save the image.
             *
             * ###Example:
             *
-            *     var contour = new Contour(...)
+            *     var chart = new Contour(...)
             *         ...
             *         .exportable()
             *         .render();
+            *
             *     document.getElementById('save').onclick = function () {
-            *         contour.download({
+            *         chart.download({
             *             fileName: 'contour.png',
             *             width: 640
             *         });
             *
             * @name download
-            * @param {object} options Configuration options specific to saving the image.
-            *     `type` specifies the mime type of the image. See http://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support for browser support. (Default: 'image/png'.)
-            *     `fileName` specifies the fileName for the download. (Default: 'contour.png'.)
-            *     `backgroundColor` specifies the fill color of the image, or `null` for transparent background. (Default: '#fff'.)
-            *     `width` specifies the width of the exported image. If `height` is falsy then the height will be scaled proportionally. (Default: `undefined` which means don't do any scaling.)
-            *     `height` specifies the height of the exported image. If `width` is falsy then the width will be scaled proportionally. (Default: `undefined` which means don't do any scaling.)
+            * @param {object} options Configuration options specific to downloading the image.
+            * @param {string} options.type Specifies the mime type of the image. See http://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support for browser support. Default: 'image/png'.
+            * @param {string} options.fileName Specifies the file name for the download. Default: 'contour.png'.
+            * @param {string} options.backgroundColor Specifies the fill color of the image. Use `null` for transparent background. Default: '#fff'.
+            * @param {int} options.width Specifies the width of the exported image. If `height` is falsy then the height is scaled proportionally. Default: `undefined`, which means don't do any scaling.
+            * @param {int} options.height Specifies the height of the exported image. If `width` is falsy then the width is scaled proportionally. Default: `undefined`, which means don't do any scaling.
             */
             download: function (options) {
                 var container = this.container;
@@ -136,22 +138,22 @@
             *
             * ###Example:
             *
-            *     var contour = new Contour(...)
+            *     var chart = new Contour(...)
             *         ...
             *         .exportable()
             *         .render();
             *     document.getElementById('save').onclick = function () {
-            *         contour.place({
+            *         chart.place({
             *             target: '#image'
             *         });
             *
             * @name place
-            * @param {object} options Configuration options specific to saving the image.
-            *     `type` specifies the mime type of the image. See http://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support for browser support. (Default: 'image/png'.)
-            *     `target` specifies a selector for the container. (For example: '#image' will append the image into `<div id="image"></div>`.)
-            *     `backgroundColor` specifies the fill color of the image, or `null` for transparent background. (Default: '#fff'.)
-            *     `width` specifies the width of the exported image. If `height` is falsy then the height will be scaled proportionally. (Default: `undefined` which means don't do any scaling.)
-            *     `height` specifies the height of the exported image. If `width` is falsy then the width will be scaled proportionally. (Default: `undefined` which means don't do any scaling.)
+            * @param {object} options Configuration options specific to placing the image in a container.
+            * @param {string} options.type Specifies the mime type of the image. See http://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support for browser support. Default: 'image/png'.
+            * @param {string} options.target Specifies a selector for the container. For example: '#image' will append the image into `<div id="image"></div>`.
+            * @param {string} options.backgroundColor Specifies the fill color of the image. Use `null` for transparent background. Default: '#fff'.
+            * @param {int} options.width Specifies the width of the exported image. If `height` is falsy then the height is scaled proportionally. Default: `undefined`, which means don't do any scaling.
+            * @param {int} options.height specifies the height of the exported image. If `width` is falsy then the width is scaled proportionally. Default: `undefined` which means don't do any scaling.
             */
             place: function (options) {
                 var container = this.container;


### PR DESCRIPTION

also update examples to not use the default param values, and use more
present tense