### PR TITLE
move scale.nice() out for chart rendering multiple times to keep same…

### DIFF
--- a/src/scripts/core/axis/linear-scale-axis.js
+++ b/src/scripts/core/axis/linear-scale-axis.js
@@ -17,10 +17,12 @@
             this._domain = domain ? this._getAxisDomain(domain) : this._getAxisDomain(this.data);
             if(!this._scale) {
                 this._scale = d3.scale.linear().domain(this._domain);
-                if(this.options.xAxis.min == null && this.options.xAxis.max == null)
-                    this._scale.nice();
             } else {
                 this._scale.domain(this._domain);
+            }
+
+            if(this.options.xAxis.min == null && this.options.xAxis.max == null){
+                this._scale.nice();
             }
 
             this._setRange();


### PR DESCRIPTION
… xAxis value 

Currently, if the same chart renders more than once the nice() scale won't be called on the second time, causing the last tick to disappear sometimes.  