### PR TITLE
Materialize configuration options parameters that are functions.

### DIFF
--- a/src/documentation/config/config.md
+++ b/src/documentation/config/config.md
@@ -38,11 +38,11 @@ Each configuration option can be:
 
 		columnWidth: function() { return this.rangeBand/3 * 2; }
 
-	__Note__ Function parameters will be invoked just before each render happens or in the within the render cycle with the corresponding data point in the following cases:
-	* function expects a parameter (ie. `function (d) { return d.x; }`)
-	* parameter path is in the `options.skip`
-	* parameter path matches the RegExp `options.skipMatch`
+	__Note__ In general, function parameters will be invoked just before the render cycle happens except when:
+	* the function expects 1 or more parameters (ie. `function (d) { return d.x; }`) or
+	* the parameter path matches or is in  the `options.skip` array. The `options.skip` array can have string with a full path to skip or a RegExp to match a path. For example `['line.marker.enable', /formatter/i]` would skip the options `line.marker.enable` and any options called `formatter`.
 
+This allows functions to be used for things like formatters that need to be called for each point in the data set.
 
 <% if(notes) { %><%= notes %><% } %>
 

--- a/src/scripts/core/contour-utils.js
+++ b/src/scripts/core/contour-utils.js
@@ -310,6 +310,10 @@
                     var expectsParam = (typeof object[key] === 'function' && !!object[key].length);
                     var shouldMaterialize = !shouldSkip(curKeyPath) && !expectsParam;
 
+                    if (expectsParam && !shouldSkip(curKeyPath)) {
+                        console.warn('The funciton "' + curKeyPath + '" expects parameters and will not be resolved to a value before the render starts. It is assumed to be used inside a visualization. Add this function to the "skip" list to remove this message.');
+                    }
+
                     if (shouldMaterialize) {
                         prev[key] = generalHelpers.materialize(object[key], ctx, options, curKeyPath);
                     } else {

--- a/src/scripts/core/contour.js
+++ b/src/scripts/core/contour.js
@@ -315,7 +315,8 @@
             this._extraOptions.forEach(mergeExtraOptions);
             this._visualizations.forEach(mergeDefaults);
 
-            var opt = nwt.materialize(this.originalOptions, this, { skipMatch: /formatter/ });
+            var forceSkip = ['skip', /formatter/, 'el'];
+            var opt = nwt.materialize(this.originalOptions, this, { skip: forceSkip.concat(this.originalOptions.skip) });
 
             // compose the final list of options right before start rendering
             this.options = nwt.merge(opt, nwt.merge({}, allDefaults, opt));

--- a/tests/specs/contour-utils-spec.js
+++ b/tests/specs/contour-utils-spec.js
@@ -478,8 +478,7 @@ describe('utils', function () {
 
 
                 res = mat(input, expectedContext, {
-                    skip: ['x', 'd.x'],
-                    skipMatch: /zzz/
+                    skip: ['x', 'd.x', /zzz/],
                 });
             });
 

--- a/tests/specs/core-spec.js
+++ b/tests/specs/core-spec.js
@@ -373,4 +373,30 @@ describe('Contour', function () {
         });
     });
 
+    describe('composeOptions', function () {
+        var instance;
+        var formatter = function () { return 1; };
+        beforeEach(function () {
+            instance = createContour({
+                width: function () { return 80; },
+                skip: ['abc'],
+                formatter: formatter
+            });
+        });
+
+        it('should call options to materialzie', function () {
+            instance.composeOptions();
+            expect(instance.options).toEqual(jasmine.objectContaining({
+                width: 80,
+            }));
+        });
+        it('should not materialize skip list plus defaults', function () {
+            instance.composeOptions();
+            expect(instance.options).toEqual(jasmine.objectContaining({
+                skip: ['abc'],
+                formatter: formatter
+            }));
+        });
+    });
+
 });


### PR DESCRIPTION
This allows to specify any configuration option as a function. This functions will be called just before the rendering starts. Some functions are not "materialized" as they expect to be called with some data within the context of the render cycle for example data formatters expect to be called for each point in the data set. These functions are not materialized before the render starts and are called in the context of the specific visualization.