### PR TITLE
Ensure subsequent calls to render background updates g

### DIFF
--- a/src/scripts/core/cartesian.js
+++ b/src/scripts/core/cartesian.js
@@ -522,9 +522,9 @@
                 this.background = this.background || this.createVisualizationLayer('background', 0);
                 var g = this.background.selectAll('.plot-area-background').data([null]);
 
-                g.enter().append('rect')
-                    .attr('class', 'plot-area-background')
-                    .attr('x', options.internalPadding.left)
+                g.enter().append('rect').attr('class', 'plot-area-background');
+
+                g.attr('x', options.internalPadding.left)
                     .attr('y', options.internalPadding.top)
                     .attr('width', options.plotWidth)
                     .attr('height', options.plotHeight);


### PR DESCRIPTION
Bug that was found when working on SALT-124; Background element wasn't being properly rerendered b/c the `attr` calls tailed the `enter` function chain.