### PR TITLE
pie-chart-tooltips Fix 'undefined' in pie chart demos

### DIFF
--- a/examples/showcase/pie/donut-series/demo.js
+++ b/examples/showcase/pie/donut-series/demo.js
@@ -45,6 +45,11 @@ $(function () {
                 hAlign: 'center',
                 vAlign: 'bottom',
                 direction: 'horizontal'
+            },
+            tooltip: {
+                formatter: function(d) {
+                    return d.data.x + ': ' + d.data.y;
+                }
             }
         })
         .pie(data)

--- a/examples/showcase/pie/pie-series/demo.js
+++ b/examples/showcase/pie/pie-series/demo.js
@@ -42,6 +42,11 @@ $(function () {
                 hAlign: 'center',
                 vAlign: 'bottom',
                 direction: 'horizontal'
+            },
+            tooltip: {
+                formatter: function(d) {
+                    return d.data.x + ': ' + d.data.y;
+                }
             }
         })
         .pie(data)


### PR DESCRIPTION
I don't think that pie charts' tooltips have access to the series name, so this makes the tooltips read (for example)
```
Prod A: 4
```

instead of 

```
undefined
Prod A
4
```